### PR TITLE
Python 3.x support

### DIFF
--- a/Chessnut/game.py
+++ b/Chessnut/game.py
@@ -61,7 +61,7 @@ class Game(object):
         """
         Convert a board index to algebraic notation.
         """
-        return chr(97 + pos_idx % 8) + str(8 - pos_idx / 8)
+        return chr(97 + pos_idx % 8) + str(8 - pos_idx // 8)
 
     @staticmethod
     def xy2i(pos_xy):
@@ -186,7 +186,7 @@ class Game(object):
         # state update must happen after castling
         self.set_fen(' '.join(str(x) for x in [self.board] + list(fields)))
 
-    def get_moves(self, player=None, idx_list=xrange(64)):
+    def get_moves(self, player=None, idx_list=range(64)):
         """
         Get a list containing the legal moves for pieces owned by the
         specified player that are located at positions included in the
@@ -232,7 +232,7 @@ class Game(object):
 
         return res_moves
 
-    def _all_moves(self, player=None, idx_list=xrange(64)):
+    def _all_moves(self, player=None, idx_list=range(64)):
         """
         Get a list containing all reachable moves for pieces owned by the
         specified player (including moves that would expose the player's king

--- a/Chessnut/moves.py
+++ b/Chessnut/moves.py
@@ -80,12 +80,12 @@ for sym, is_legal in PIECES.items():
 
     MOVES[sym] = list()
 
-    for idx in xrange(64):
+    for idx in range(64):
 
         # Initialize arrays for each of the 8 possible directions that a
         # piece could be moved; some of these will be empty and
         # removed later
-        MOVES[sym].append([list() for _ in xrange(8)])
+        MOVES[sym].append([list() for _ in range(8)])
 
         # Sorting the list of end points by distance from the starting
         # point ensures that the ouptut order is properly sorted
@@ -93,9 +93,9 @@ for sym, is_legal in PIECES.items():
 
             # Determine the row, change in column, and change in row
             # of the start/end point pair for move validation
-            y = 8 - idx / 8
+            y = 8 - idx // 8
             dx = (end % 8) - (idx % 8)
-            dy = (8 - end / 8) - y
+            dy = (8 - end // 8) - y
 
             if idx == end or not is_legal(y, dx, dy):
                 continue
@@ -125,7 +125,7 @@ MOVES['K'][60][4].append(58)
 
 # Directly add double-space pawn opening moves
 IDX = 0
-for i in xrange(8):
+for i in range(8):
     MOVES['p'][8 + i][IDX].append(24 + i)
     MOVES['P'][55 - i][IDX].append(39 - i)
     IDX = 1


### PR DESCRIPTION
I wanted to use this library with Python 3, but because it uses xrange() and implicit integer division (rather than `//` integer division) it doesn't work.

The division changes are perfectly safe, and I believe xrange->range won't introduce any performance issues on Python 2.x, though it may be a slight regression. Changing the function call seemed a little nicer than introducing an xrange alias for Python 3.