### PR TITLE
Issue #13 allow short algebraic notation moves.

### DIFF
--- a/Chessnut/board.py
+++ b/Chessnut/board.py
@@ -77,3 +77,10 @@ class Board(object):
         piece is not on the board.
         """
         return ''.join(self._position).find(symbol)
+
+    def find_all_pieces(self, symbol):
+        """
+        Find all indexes of the specified piece on the board, returns an empty list
+        if the piece is not on the board.
+        """
+        return [indx for indx, piece in enumerate(self._position) if piece == symbol]

--- a/Chessnut/tests/test_board.py
+++ b/Chessnut/tests/test_board.py
@@ -25,3 +25,9 @@ class BoardTest(unittest.TestCase):
         self.board.move_piece(52, 36, 'P')  # e2e4
         self.assertEqual(str(self.board),
                          'rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR')
+
+    def test_find_all_pieces(self):
+        self.board.set_position('rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR')
+        self.assertEqual(self.board.find_all_pieces('P'), [48, 49, 50, 51, 52, 53, 54, 55])
+        self.assertEqual(self.board.find_all_pieces('R'), [56, 63])
+        self.assertEqual(self.board.find_all_pieces('r'), [0, 7])

--- a/Chessnut/tests/test_game.py
+++ b/Chessnut/tests/test_game.py
@@ -1,6 +1,6 @@
 
 import unittest
-from Chessnut.game import Game, InvalidMove
+from Chessnut.game import Game, InvalidMove, San
 
 
 # Default FEN string
@@ -22,7 +22,7 @@ class GameTest(unittest.TestCase):
         self.game = Game()
 
     def test_i2xy(self):
-        for idx in xrange(64):
+        for idx in range(64):
             self.assertIn(Game.i2xy(idx), ALG_POS)
 
     def test_xy2i(self):
@@ -165,6 +165,69 @@ class GameTest(unittest.TestCase):
         with self.assertRaises(InvalidMove):
             self.game.apply_move('e2e2')
 
+    def test_apply_san_move(self):
+        # pawn promotion
+        fen = '3qk1b1/P7/8/8/8/8/7P/4K3 w - - 0 1'
+        self.game = Game(fen=fen)
+        self.game.apply_san_move('a8=Q')
+        self.assertEqual(str(self.game), 'Q2qk1b1/8/8/8/8/8/7P/4K3 b - - 0 1')
+
+        # apply moves
+        self.game.apply_san_move('Bh7')
+        self.assertEqual(str(self.game), 'Q2qk3/7b/8/8/8/8/7P/4K3 w - - 1 2')
+        self.game.apply_san_move('h4')
+        self.assertEqual(str(self.game), 'Q2qk3/7b/8/8/7P/8/8/4K3 b - h3 0 2')
+
+        # white castling
+        fen = 'r3k2r/pppqbppp/3pb3/8/8/3PB3/PPPQBPPP/R3K2R w KQkq - 0 7'
+        new_fen = 'r3k2r/pppqbppp/3pb3/8/8/3PB3/PPPQBPPP/R4RK1 b kq - 1 7'
+        self.game = Game(fen=fen)
+        self.game.apply_san_move('0-0')
+        self.assertEqual(str(self.game), new_fen)
+        new_fen = 'r3k2r/pppqbppp/3pb3/8/8/3PB3/PPPQBPPP/2KR3R b kq - 1 7'
+        self.game = Game(fen=fen)
+        self.game.apply_san_move('0-0-0')
+        self.assertEqual(str(self.game), new_fen)
+
+        # black castling
+        fen = 'r3k2r/pppqbppp/3pb3/8/8/3PB3/PPPQBPPP/R3K2R b KQkq - 0 7'
+        new_fen = 'r4rk1/pppqbppp/3pb3/8/8/3PB3/PPPQBPPP/R3K2R w KQ - 1 8'
+        self.game = Game(fen=fen)
+        self.game.apply_san_move('0-0')
+        self.assertEqual(str(self.game), new_fen)
+        new_fen = '2kr3r/pppqbppp/3pb3/8/8/3PB3/PPPQBPPP/R3K2R w KQ - 1 8'
+        self.game = Game(fen=fen)
+        self.game.apply_san_move('0-0-0')
+        self.assertEqual(str(self.game), new_fen)
+
+        # Disable castling on capture
+        fen = '1r2k2r/3nb1Qp/p1pp4/3p4/3P4/P1N2P2/1PP3PP/R1B3K1 w k - 0 22'
+        new_fen = '1r2k2Q/3nb2p/p1pp4/3p4/3P4/P1N2P2/1PP3PP/R1B3K1 b - - 0 22'
+        self.game = Game(fen=fen)
+        self.game.apply_san_move('Qxh8')
+        self.assertEqual(str(self.game), new_fen)
+
+        # white en passant
+        fen = 'rnbqkbnr/ppp2ppp/4p3/3pP3/8/8/PPPP1PPP/RNBQKBNR w KQkq d6 0 1'
+        self.game = Game(fen=fen)
+        self.game.apply_san_move('exd6')
+        new_fen = 'rnbqkbnr/ppp2ppp/3Pp3/8/8/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1'
+        self.assertEqual(str(self.game), new_fen)
+
+        # black en passant
+        fen = 'rnbqkbnr/ppp1pppp/8/8/3pP3/8/PPPP1PPP/RNBQKBNR b KQkq e3 0 1'
+        self.game = Game(fen=fen)
+        self.game.apply_san_move('dxe3')
+        new_fen = 'rnbqkbnr/ppp1pppp/8/8/8/4p3/PPPP1PPP/RNBQKBNR w KQkq - 0 2'
+        self.assertEqual(str(self.game), new_fen)
+
+        # capture
+        fen = 'r2q1rk1/pppbbppp/2n5/3p4/3PN3/4PN2/1PPBBPPP/R2Q1RK1 b - - 0 9'
+        self.game = Game(fen=fen)
+        self.game.apply_san_move('dxe4')
+        n_fen = 'r2q1rk1/pppbbppp/2n5/8/3Pp3/4PN2/1PPBBPPP/R2Q1RK1 w - - 0 10'
+        self.assertEqual(str(self.game), n_fen)
+
     def test_status(self):
 
         # NORMAL
@@ -182,3 +245,83 @@ class GameTest(unittest.TestCase):
         # STALEMATE
         game = Game(fen='8/8/8/8/8/7k/5q2/7K w - - 0 37')
         self.assertEqual(game.status, Game.STALEMATE)
+
+    def test_san_to_long(self):
+        self.game.reset()  # reset board to starting position
+        game = [
+            'e4', 'e5',
+            'Nf3', 'd6',
+            'd4', 'Bg4',
+            'dxe5', 'Bxf3',
+            'Qxf3', 'dxe5',
+            'Bc4', 'Nf6',
+            'Qb3', 'Qe7',
+            'Nc3', 'c6',
+            'Bg5', 'b5',
+            'Nxb5', 'cxb5',
+            'Bxb5', 'Nbd7',
+            '0-0-0', 'Rd8',
+            'Rxd7', 'Rxd7',
+            'Rd1', 'Qe6',
+            'Bxd7', 'Nxd7',
+            'Qb8+', 'Nxb8',
+            'Rd8++'
+        ]
+        for move in game:
+            self.game.apply_san_move(move)
+        self.assertEqual(self.game.get_fen(), '1n1Rkb1r/p4ppp/4q3/4p1B1/4P3/8/PPP2PPP/2K5 b k - 1 17')
+
+        self.game = Game(fen='8/P7/1K6/8/k7/8/8/8 w - - 0 40')
+        self.game.apply_san_move('a8=Q')
+        self.assertEqual(self.game.get_fen(), 'Q7/8/1K6/8/k7/8/8/8 b - - 0 40')
+
+        self.game = Game(fen='8/8/1K6/8/k7/8/p7/8 b - - 0 40')
+        self.game.apply_san_move('a1=Q')
+        self.assertEqual(self.game.get_fen(), '8/8/1K6/8/k7/8/8/q7 w - - 0 41')
+
+
+class SanTest(unittest.TestCase):
+    def test_simple_move(self):
+        san = San('Rc1')
+        self.assertEqual(san.piece, 'R')
+        self.assertEqual(san.end_square, 'c1')
+
+    def test_from_hints(self):
+        san = San('Rac1')
+        self.assertEqual(san.piece, 'R')
+        self.assertEqual(san.end_square, 'c1')
+        self.assertEqual(san.from_hints, 'a')
+
+        san = San('R1c1')
+        self.assertEqual(san.piece, 'R')
+        self.assertEqual(san.end_square, 'c1')
+        self.assertEqual(san.from_hints, '1')
+
+        san = San('Rac1')
+        self.assertEqual(san.piece, 'R')
+        self.assertEqual(san.end_square, 'c1')
+        self.assertEqual(san.from_hints, 'a')
+
+        san = San('Ra1c1')
+        self.assertEqual(san.piece, 'R')
+        self.assertEqual(san.end_square, 'c1')
+        self.assertEqual(san.from_hints, 'a1')
+
+    def test_promotion(self):
+        san = San('e8=Q')
+        self.assertEqual(san.piece, '')
+        self.assertEqual(san.end_square, 'e8')
+        self.assertEqual(san.promotion, 'Q')
+
+    def test_castling(self):
+        san = San('0-0-0')
+        self.assertEqual(san.castling, 'Q')
+
+        san = San('O-O-O')
+        self.assertEqual(san.castling, 'Q')
+
+        san = San('0-0')
+        self.assertEqual(san.castling, 'K')
+
+        san = San('O-O')
+        self.assertEqual(san.castling, 'K')

--- a/Chessnut/tests/test_moves.py
+++ b/Chessnut/tests/test_moves.py
@@ -14,7 +14,7 @@ class MovesTest(unittest.TestCase):
             self.assertIn(piece, MOVES)
 
             # test that every starting position is in the dictionary
-            for idx in xrange(64):
+            for idx in range(64):
                 self.assertIsNotNone(MOVES[piece][idx])
 
                 # test ordering of moves in each ray (should radiate out

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-coverage==3.7
+coverage==4.3.4


### PR DESCRIPTION
Add a San class to parse and store the internals of a short algebraic move.
Add san_to_long method to Game to convert the san move to the long version.
Add apply_san_move method to Game to apply the move

Replace xrange with range so that tests run in python3

Add find_all_pieces method to Board similar to find_piece, but returns a list of all indexes instead of just the first one.

Add tests to cover all the new code.