### PR TITLE
Allow a pawn to put a king in check on last line + test

### DIFF
--- a/Chessnut/game.py
+++ b/Chessnut/game.py
@@ -354,8 +354,8 @@ class Game(object):
         k_sym, opp = {'w': ('K', 'b'), 'b': ('k', 'w')}.get(self.state.player)
         k_loc = Game.i2xy(self.board.find_piece(k_sym))
         can_move = len(self.get_moves())
-        is_exposed = [m[2:] for m in self._all_moves(player=opp)
-                      if m[2:] == k_loc]
+        is_exposed = [m[2:4] for m in self._all_moves(player=opp)
+                      if m[2:4] == k_loc]
 
         status = Game.NORMAL
         if is_exposed:

--- a/Chessnut/tests/test_game.py
+++ b/Chessnut/tests/test_game.py
@@ -22,7 +22,7 @@ class GameTest(unittest.TestCase):
         self.game = Game()
 
     def test_i2xy(self):
-        for idx in xrange(64):
+        for idx in range(64):
             self.assertIn(Game.i2xy(idx), ALG_POS)
 
     def test_xy2i(self):
@@ -182,3 +182,10 @@ class GameTest(unittest.TestCase):
         # STALEMATE
         game = Game(fen='8/8/8/8/8/7k/5q2/7K w - - 0 37')
         self.assertEqual(game.status, Game.STALEMATE)
+
+    def test_last_line_pawn_check(self):
+        # If a pawn is able to expose a king on its last line
+        game = Game(fen='8/5b2/8/6P1/8/p7/1pk5/K7 w - - 0 51')
+        self.assertEqual(game.status, Game.CHECKMATE)
+        
+

--- a/Chessnut/tests/test_moves.py
+++ b/Chessnut/tests/test_moves.py
@@ -14,7 +14,7 @@ class MovesTest(unittest.TestCase):
             self.assertIn(piece, MOVES)
 
             # test that every starting position is in the dictionary
-            for idx in xrange(64):
+            for idx in range(64):
                 self.assertIsNotNone(MOVES[piece][idx])
 
                 # test ordering of moves in each ray (should radiate out


### PR DESCRIPTION
A move for a pawn going on the last line is a promotion : departure, arrival, promotion piece.

This special moves format make the "in check" test fails when comparing king position to pawn destination.

Test cases has been added.